### PR TITLE
Dev export vocab tokens (#8)

### DIFF
--- a/MLAgentsProject/Assets/Editor/PostBuildProcessor.cs
+++ b/MLAgentsProject/Assets/Editor/PostBuildProcessor.cs
@@ -28,6 +28,6 @@ public class PostBuildProcessor : IPostprocessBuildWithReport
 
     private static string GetProjectRootPath()
     {
-        return Path.Combine(Application.dataPath, DatabaseConstants.UpDirectoryLevel);
+        return Path.Combine(Application.dataPath, Constants.UpDirectoryLevel);
     }
 }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Agents/BaseAgent.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Agents/BaseAgent.cs
@@ -52,7 +52,7 @@ public abstract class BaseAgent<TDelegator, TAgent> : Agent, IBaseAgent
     {
         try
         {
-            if (Data.Observations != null && Data.Observations.Length == DatabaseConstants.VectorSize)
+            if (Data.Observations != null && Data.Observations.Length == Constants.VectorSize)
             {
                 sensor.AddObservation(Data.Observations);
             }
@@ -124,9 +124,9 @@ public abstract class BaseAgent<TDelegator, TAgent> : Agent, IBaseAgent
 
     protected bool CheckActionLength(int length)
     {
-        if (length != DatabaseConstants.VectorSize)
+        if (length != Constants.VectorSize)
         {
-            throw new ArgumentException($"Expected {DatabaseConstants.VectorSize} continuous actions, but received {length}.");
+            throw new ArgumentException($"Expected {Constants.VectorSize} continuous actions, but received {length}.");
         }
         return true;
     }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Embedding.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Embedding.cs
@@ -12,7 +12,7 @@ public class Embedding
 
     public Embedding(int id, string token, double[] vector, EmbeddingType type)
     {
-        if (vector.Length != DatabaseConstants.VectorSize)
+        if (vector.Length != Constants.VectorSize)
         {
             throw new ArgumentException("Embedding vector must be of size 384.");
         }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+[System.Serializable]
+public class Token
+{
+    public int Id;
+    public string Name;
+    public List<double> Vector;
+
+    public Token(int id, string name, double[] vector)
+    {
+        if (vector.Length != DatabaseConstants.TokenSize)
+        {
+            throw new ArgumentException("Token vector must be of size 3.");
+        }
+
+        Id = id;
+        Name = name;
+        Vector = new List<double>(vector);
+    }
+}

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 
-[System.Serializable]
+[Serializable]
 public class Token
 {
     public int Id;
@@ -11,9 +10,9 @@ public class Token
 
     public Token(int id, string name, double[] vector)
     {
-        if (vector.Length != DatabaseConstants.TokenSize)
+        if (vector.Length != Constants.TokenSize && vector.Length != Constants.VectorSize)
         {
-            throw new ArgumentException("Token vector must be of size 3.");
+            throw new ArgumentException($"Token vector must be of size {Constants.TokenSize} or {Constants.VectorSize}.");
         }
 
         Id = id;

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs.meta
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/Token.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9182018c804c81245b69078e33d23e4e

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+[System.Serializable]
+public class TokenList
+{
+    public string version;
+    public string model_name;
+    public string organization;
+    public List<Token> token_data;
+
+    public TokenList()
+    {
+        token_data = new List<Token>();
+    }
+}

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs
@@ -6,10 +6,11 @@ public class TokenList
     public string version;
     public string model_name;
     public string organization;
-    public List<Token> token_data;
+    public int total_tokens;
+    public List<Token> tokens;
 
     public TokenList()
     {
-        token_data = new List<Token>();
+        tokens = new List<Token>();
     }
 }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs.meta
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/DataObjects/TokenList.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e55c4005d5f12774ea3aa9dd5a46db40

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataConcatAction.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataConcatAction.cs
@@ -13,7 +13,7 @@ public static class DataConcatAction
             bool isFirstFile = true;
             string firstArg = args[0].String;
             string firstArgPath = DataUtilities.GetFilePath(firstArg);
-            string saveFileName = DatabaseConstants.DefaultDataFileName;
+            string saveFileName = Constants.DefaultDataFileName;
             List<string> fileNames = new();
             MessageList combined = new();
 

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataListAction.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataListAction.cs
@@ -9,7 +9,7 @@ public static class DataListAction
     {
         try
         {
-            string dataDirectory = Path.Combine(Application.dataPath, DatabaseConstants.UpDirectoryLevel, DatabaseConstants.DataDirectoryName);
+            string dataDirectory = Path.Combine(Application.dataPath, Constants.UpDirectoryLevel, Constants.DataDirectoryName);
             var jsonFiles = DataUtilities.GetDirectoryContents(dataDirectory, "*.json");
 
             if (jsonFiles.Count == 0)

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataLoadAction.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataLoadAction.cs
@@ -22,9 +22,9 @@ public static class DataLoadAction
 
         MessageList combinedMessageList = new MessageList
         {
-            version = DatabaseConstants.Version,
-            model_name = DatabaseConstants.ModelName,
-            organization = DatabaseConstants.Organization,
+            version = Constants.Version,
+            model_name = Constants.ModelName,
+            organization = Constants.Organization,
             training_data = new List<Message>(),
             evaluation_data = new List<Message>()
         };

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataLoadAction.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Actions/Data/DataLoadAction.cs
@@ -20,12 +20,11 @@ public static class DataLoadAction
         Stopwatch stopwatch = Stopwatch.StartNew();
         Log.Message($"Starting to load training data from {string.Join(", ", fileNames)}...");
 
-        // Initialize a combined message list
         MessageList combinedMessageList = new MessageList
         {
-            version = "0.1.0",
-            model_name = "Tau",
-            organization = "Huggingface",
+            version = DatabaseConstants.Version,
+            model_name = DatabaseConstants.ModelName,
+            organization = DatabaseConstants.Organization,
             training_data = new List<Message>(),
             evaluation_data = new List<Message>()
         };
@@ -41,12 +40,9 @@ public static class DataLoadAction
                 Log.Message($"Version: {messageList.version}");
                 Log.Message($"Model Name: {messageList.model_name}");
                 Log.Message($"Organization: {messageList.organization}");
-
-                // Log the size of training and evaluation data
                 Log.Message($"Training data size: {messageList.training_data.Count}");
                 Log.Message($"Evaluation data size: {messageList.evaluation_data.Count}");
 
-                // Append the data to the combined message list
                 combinedMessageList.training_data.AddRange(messageList.training_data);
                 combinedMessageList.evaluation_data.AddRange(messageList.evaluation_data);
 
@@ -59,7 +55,6 @@ public static class DataLoadAction
             }
         }
 
-        // Use the combined message list
         await DataLoader.LoadData(combinedMessageList);
 
         stopwatch.Stop();

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseConstants.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseConstants.cs
@@ -19,4 +19,5 @@ public static class DatabaseConstants
     public const int MaxTableWidth = 110;
     public const int MaxLogLength = 110;
     public const int VectorSize = 384;
+    public const int TokenSize = 3;
 }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseConstants.cs.meta
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseConstants.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: f430e30805df90a41b64a762fc3c0707

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseManager.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Core/DatabaseManager.cs
@@ -20,8 +20,8 @@ public class DatabaseManager
     public void CreateTable(string tableName) => _tableManager.CreateTable(tableName);
     public void DeleteTable(string tableName) => _tableManager.DeleteTable(tableName);
     public void ListTables() => _tableManager.ListTables();
-    public void Save(string fileName = DatabaseConstants.DatabaseFileName) => _saveLoadManager.Save(fileName);
-    public void Load(string fileName = DatabaseConstants.DatabaseFileName) => _saveLoadManager.Load(fileName);
+    public void Save(string fileName = Constants.DatabaseFileName) => _saveLoadManager.Save(fileName);
+    public void Load(string fileName = Constants.DatabaseFileName) => _saveLoadManager.Load(fileName);
     public void Clear() => _tableManager.Clear();
     public Dictionary<string, List<Embedding>> GetTables() => _tableManager.GetTables();
     public Dictionary<string, Embedding> GetTable(string tableName) => _tableManager.GetTable(tableName);

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Data/DataLoader.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Data/DataLoader.cs
@@ -12,10 +12,10 @@ public static class DataLoader
         var (chunkedTrainingData, combinedTrainingData) = ProcessAndLogData(messageList.training_data, "training");
         var (chunkedEvaluationData, combinedEvaluationData) = ProcessAndLogData(messageList.evaluation_data, "evaluation");
 
-        Tokenizer.Export(TableNames.Vocabulary, vocabulary, DatabaseConstants.Version, DatabaseConstants.ModelName, DatabaseConstants.Organization);
-
         await DatabaseUtilities.BuildAndPopulateTables(vocabulary, combinedTrainingData, combinedEvaluationData);
         await DatabaseUtilities.AggregateAndStoreEmbeddings(chunkedTrainingData, chunkedEvaluationData);
+
+        Tokenizer.Export(vocabulary);
 
         LogTableInfo();
     }
@@ -95,7 +95,7 @@ public static class DataLoader
             Log.Message($"Sample {dataType} message: {dataList[0]}");
         }
 
-        Dictionary<string, List<string>> chunkedData = Tokenizer.ChunkText(dataList);
+        Dictionary<string, List<string>> chunkedData = TokenizerUtilities.ChunkText(dataList);
         List<string> combinedData = chunkedData.Values.SelectMany(chunks => chunks).ToList();
 
         // Include short texts that were not chunked

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Embedding/EmbeddingStorage.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Embedding/EmbeddingStorage.cs
@@ -108,7 +108,7 @@ public class EmbeddingStorage
             Vectors = vectors,
             QueryVector = query,
             Results = results,
-            VectorSize = DatabaseConstants.VectorSize
+            VectorSize = Constants.VectorSize
         };
 
         JobHandle handle = job.Schedule(embeddings.Count, 64);

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Finder/ResultsFormatter.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Finder/ResultsFormatter.cs
@@ -15,9 +15,9 @@ public class ResultFormatter
         int typeColumnWidth = FinderUtilities.CalculateColumnWidth("Type", results.Select(r => r.Embedding?.Type.ToString() ?? ""), 10);
         int tokenColumnWidth = FinderUtilities.CalculateColumnWidth("Token", results.Select(r => r.Embedding?.Token ?? ""), 30, maxTokenLength);
         int tableColumnWidth = FinderUtilities.CalculateColumnWidth("Table", results.Select(r => r.TableName), 15);
-        int embeddingColumnWidth = DatabaseConstants.MaxTableWidth - (idColumnWidth + typeColumnWidth + tokenColumnWidth + tableColumnWidth + 10);
+        int embeddingColumnWidth = Constants.MaxTableWidth - (idColumnWidth + typeColumnWidth + tokenColumnWidth + tableColumnWidth + 10);
 
-        string separator = new string(DatabaseConstants.TableSeparator, DatabaseConstants.MaxTableWidth + 3);
+        string separator = new string(Constants.TableSeparator, Constants.MaxTableWidth + 3);
         var result = new StringBuilder();
         result.AppendLine(separator);
         result.AppendLine(FinderUtilities.FormatHeader(idColumnWidth, typeColumnWidth, tokenColumnWidth, tableColumnWidth, embeddingColumnWidth));

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/IO/SaveLoadManager.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/IO/SaveLoadManager.cs
@@ -13,11 +13,11 @@ public class SaveLoadManager
         _info = info;
     }
 
-    public void Save(string fileName = DatabaseConstants.DatabaseFileName)
+    public void Save(string fileName = Constants.DatabaseFileName)
     {
         if (string.IsNullOrEmpty(fileName))
         {
-            fileName = DatabaseConstants.DatabaseFileName;
+            fileName = Constants.DatabaseFileName;
         }
 
         string filePath = DataUtilities.GetFilePath(fileName);
@@ -44,11 +44,11 @@ public class SaveLoadManager
         Log.Message($"Database saved to {filePath} (Elapsed time: {stopwatch.Elapsed.TotalSeconds} seconds)");
     }
 
-    public void Load(string fileName = DatabaseConstants.DatabaseFileName)
+    public void Load(string fileName = Constants.DatabaseFileName)
     {
         if (string.IsNullOrEmpty(fileName))
         {
-            fileName = DatabaseConstants.DatabaseFileName;
+            fileName = Constants.DatabaseFileName;
         }
 
         string filePath = DataUtilities.GetFilePath(fileName);

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableBuilder.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableBuilder.cs
@@ -42,7 +42,7 @@ public class TableBuilder
         Stopwatch stopwatch = Stopwatch.StartNew();
 
         // Include reserved words in the total token count only if it's the vocabulary table
-        int reservedWordsCount = isVocabulary ? DatabaseConstants.ReservedWords.Length : 0;
+        int reservedWordsCount = isVocabulary ? Constants.ReservedWords.Length : 0;
         int totalTokens = tokens.Count + reservedWordsCount + 1;
         var tasks = new List<Task>();
         var semaphore = new SemaphoreSlim(EmbeddingUtilities.MaxConcurrentJobs);

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableDisplay.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableDisplay.cs
@@ -50,9 +50,9 @@ public class TableDisplay
         int idColumnWidth = CalculateColumnWidth("Id", table.Values.Select(k => k.Id.ToString()), 10);
         int typeColumnWidth = CalculateColumnWidth("Type", table.Values.Select(k => k.Type.ToString()), 10);
         int tokenColumnWidth = CalculateColumnWidth("Token", table.Keys.Select(k => k), 30, maxTokenLength);
-        int embeddingColumnWidth = DatabaseConstants.MaxTableWidth - (idColumnWidth + typeColumnWidth + tokenColumnWidth + 10);
+        int embeddingColumnWidth = Constants.MaxTableWidth - (idColumnWidth + typeColumnWidth + tokenColumnWidth + 10);
 
-        string separator = new string(DatabaseConstants.TableSeparator, DatabaseConstants.MaxTableWidth + 3);
+        string separator = new string(Constants.TableSeparator, Constants.MaxTableWidth + 3);
         var results = new StringBuilder();
         results.AppendLine(separator);
         results.AppendLine(FormatHeader(idColumnWidth, typeColumnWidth, tokenColumnWidth, embeddingColumnWidth));
@@ -81,12 +81,12 @@ public class TableDisplay
 
     private string TruncateText(string text, int maxLength)
     {
-        return text.Length > maxLength ? text.Substring(0, maxLength) + DatabaseConstants.TextElipsis : text;
+        return text.Length > maxLength ? text.Substring(0, maxLength) + Constants.TextElipsis : text;
     }
 
     private string FormatEmbeddings(List<double> vector, int numEmbeddingsToShow)
     {
-        return string.Join(DatabaseConstants.VectorSeparator, vector.Take(numEmbeddingsToShow)) + (vector.Count > numEmbeddingsToShow ? DatabaseConstants.TextElipsis : "");
+        return string.Join(Constants.VectorSeparator, vector.Take(numEmbeddingsToShow)) + (vector.Count > numEmbeddingsToShow ? Constants.TextElipsis : "");
     }
 
     private string FormatTableRow(KeyValuePair<string, Embedding> entry, int idColumnWidth, int typeColumnWidth, int tokenColumnWidth, int embeddingColumnWidth, int numEmbeddingsToShow, int maxLinesPerRecord, int maxTokenLength)

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableNames.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Database/Table/TableNames.cs
@@ -1,5 +1,6 @@
 public static class TableNames
 {
+    public const string Tokens = "tokens";
     public const string Vocabulary = "vocabulary";
     public const string TrainingData = "training_data";
     public const string EvaluationData = "evaluation_data";

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global.meta
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1fede2d5590c98499b78d5947dd8150
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global/Constants.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global/Constants.cs
@@ -1,4 +1,4 @@
-public static class DatabaseConstants
+public static class Constants
 {
     public const string Version = "0.1.0";
     public const string ModelName = "Tau";
@@ -18,6 +18,8 @@ public static class DatabaseConstants
     public const char TableSeparator = '-';
     public const int MaxTableWidth = 110;
     public const int MaxLogLength = 110;
+    public const int OverlapTokens = 16;
     public const int VectorSize = 384;
+    public const int MaxTokens = 128;
     public const int TokenSize = 3;
 }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global/Constants.cs.meta
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Global/Constants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5c22a72d290e254ca033b60d0ed3aea

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Training/Rewards/IncrementalReward.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Training/Rewards/IncrementalReward.cs
@@ -6,13 +6,13 @@ public class IncrementalReward : BaseReward<double[]>
 
     public IncrementalReward(int initialColumnsToUse)
     {
-        if (initialColumnsToUse > 0 && initialColumnsToUse <= DatabaseConstants.VectorSize)
+        if (initialColumnsToUse > 0 && initialColumnsToUse <= Constants.VectorSize)
         {
             this.columnsToUse = initialColumnsToUse;
         }
         else
         {
-            throw new ArgumentException($"Invalid number of columns: {initialColumnsToUse}. Must be between 1 and {DatabaseConstants.VectorSize}.");
+            throw new ArgumentException($"Invalid number of columns: {initialColumnsToUse}. Must be between 1 and {Constants.VectorSize}.");
         }
     }
 
@@ -33,14 +33,14 @@ public class IncrementalReward : BaseReward<double[]>
 
     public void SetColumnsToUse(int columns)
     {
-        if (columns > 0 && columns <= DatabaseConstants.VectorSize)
+        if (columns > 0 && columns <= Constants.VectorSize)
         {
             columnsToUse = columns;
             Log.Message($"Columns to use set to: {columns}");
         }
         else
         {
-            throw new ArgumentException($"Invalid number of columns: {columns}. Must be between 1 and {DatabaseConstants.VectorSize}.");
+            throw new ArgumentException($"Invalid number of columns: {columns}. Must be between 1 and {Constants.VectorSize}.");
         }
     }
 }

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/DataUtilities.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/DataUtilities.cs
@@ -15,7 +15,7 @@ public static class DataUtilities
             throw new ArgumentNullException(nameof(fileName), "File name cannot be null or empty.");
         }
 
-        return Path.Combine(Application.dataPath, DatabaseConstants.UpDirectoryLevel, DatabaseConstants.DataDirectoryName, fileName);
+        return Path.Combine(Application.dataPath, Constants.UpDirectoryLevel, Constants.DataDirectoryName, fileName);
     }
 
     public static string CombineArgs(CommandArg[] args)

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/EmbeddingUtilities.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/EmbeddingUtilities.cs
@@ -9,7 +9,7 @@ public static class EmbeddingUtilities
 {
     public const int MaxConcurrentJobs = 8;
 
-    public static void ValidateEmbeddingSize(double[] embedding, int expectedSize = DatabaseConstants.VectorSize)
+    public static void ValidateEmbeddingSize(double[] embedding, int expectedSize = Constants.VectorSize)
     {
         if (embedding.Length != expectedSize)
         {

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/FinderUtilities.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/FinderUtilities.cs
@@ -19,12 +19,12 @@ public static class FinderUtilities
 
     public static string TruncateText(string text, int maxLength)
     {
-        return text.Length > maxLength ? text.Substring(0, maxLength) + DatabaseConstants.TextElipsis : text;
+        return text.Length > maxLength ? text.Substring(0, maxLength) + Constants.TextElipsis : text;
     }
 
     public static string FormatEmbeddings(List<double> vector, int numEmbeddingsToShow)
     {
-        return string.Join(DatabaseConstants.VectorSeparator, vector.Take(numEmbeddingsToShow)) + (vector.Count > numEmbeddingsToShow ? DatabaseConstants.TextElipsis : "");
+        return string.Join(Constants.VectorSeparator, vector.Take(numEmbeddingsToShow)) + (vector.Count > numEmbeddingsToShow ? Constants.TextElipsis : "");
     }
 
     public static string FormatRecord(List<string> idLines, List<string> typeLines, List<string> tokenLines, List<string> tableLines, List<string> embeddingLines, int idColumnWidth, int typeColumnWidth, int tokenColumnWidth, int tableColumnWidth, int embeddingColumnWidth)

--- a/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/StringUtilities.cs
+++ b/MLAgentsProject/Assets/MLAgentsProject/Scripts/Utilities/StringUtilities.cs
@@ -22,7 +22,7 @@ public static class StringUtilities
 
         if (start < text.Length)
         {
-            lines[lines.Count - 1] = lines[lines.Count - 1].TrimEnd() + DatabaseConstants.TextElipsis;
+            lines[lines.Count - 1] = lines[lines.Count - 1].TrimEnd() + Constants.TextElipsis;
         }
 
         return lines;
@@ -55,32 +55,32 @@ public static class StringUtilities
 
     public static string TruncateLogMessage(string message)
     {
-        if (string.IsNullOrEmpty(message) || message.Length <= DatabaseConstants.MaxLogLength)
+        if (string.IsNullOrEmpty(message) || message.Length <= Constants.MaxLogLength)
         {
             return message;
         }
 
-        return message.Substring(0, DatabaseConstants.MaxLogLength) + DatabaseConstants.TextElipsis;
+        return message.Substring(0, Constants.MaxLogLength) + Constants.TextElipsis;
     }
 
     public static string ConvertVectorToString(double[] vector)
     {
-        if (vector.Length != DatabaseConstants.VectorSize)
+        if (vector.Length != Constants.VectorSize)
         {
-            throw new ArgumentException($"Vector must be of size {DatabaseConstants.VectorSize}.");
+            throw new ArgumentException($"Vector must be of size {Constants.VectorSize}.");
         }
 
-        return "[" + string.Join(DatabaseConstants.VectorSeparator, vector.Select(v => v.ToString("F6"))) + "]";
+        return "[" + string.Join(Constants.VectorSeparator, vector.Select(v => v.ToString("F6"))) + "]";
     }
 
     public static string ConvertVectorToString(float[] vector)
     {
-        if (vector.Length != DatabaseConstants.VectorSize)
+        if (vector.Length != Constants.VectorSize)
         {
-            throw new ArgumentException($"Vector must be of size {DatabaseConstants.VectorSize}.");
+            throw new ArgumentException($"Vector must be of size {Constants.VectorSize}.");
         }
 
-        return "[" + string.Join(DatabaseConstants.VectorSeparator, vector.Select(v => v.ToString("F6"))) + "]";
+        return "[" + string.Join(Constants.VectorSeparator, vector.Select(v => v.ToString("F6"))) + "]";
     }
 
     public static double[] ConvertStringToVector(string vectorString)
@@ -90,12 +90,12 @@ public static class StringUtilities
             throw new ArgumentException("Embedding vector must be enclosed in square brackets.");
         }
 
-        string[] parts = vectorString.Trim('[', ']').Split(DatabaseConstants.VectorSeparator);
+        string[] parts = vectorString.Trim('[', ']').Split(Constants.VectorSeparator);
         double[] vector = parts.Select(double.Parse).ToArray();
 
-        if (vector.Length != DatabaseConstants.VectorSize)
+        if (vector.Length != Constants.VectorSize)
         {
-            throw new ArgumentException($"Embedding vector must be of size {DatabaseConstants.VectorSize}.");
+            throw new ArgumentException($"Embedding vector must be of size {Constants.VectorSize}.");
         }
 
         return vector;

--- a/MLAgentsProject/Packages/manifest.json
+++ b/MLAgentsProject/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ml-agents": "file:../ml-agents/com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../ml-agents/com.unity.ml-agents.extensions",
     "com.unity.postprocessing": "3.4.0",
-    "com.unity.probuilder": "6.0.3",
+    "com.unity.probuilder": "6.0.4",
     "com.unity.render-pipelines.universal": "17.0.3",
     "com.unity.settings-manager": "2.0.1",
     "com.unity.test-framework": "1.4.5",

--- a/MLAgentsProject/Packages/manifest.json
+++ b/MLAgentsProject/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "com.unity.ai.navigation": "2.0.4",
-    "com.unity.collab-proxy": "2.4.4",
+    "com.unity.collab-proxy": "2.5.1",
     "com.unity.ide.visualstudio": "2.0.22",
-    "com.unity.inputsystem": "1.10.0",
+    "com.unity.inputsystem": "1.11.0",
     "com.unity.ml-agents": "file:../ml-agents/com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../ml-agents/com.unity.ml-agents.extensions",
     "com.unity.postprocessing": "3.4.0",

--- a/MLAgentsProject/Packages/packages-lock.json
+++ b/MLAgentsProject/Packages/packages-lock.json
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.4.4",
+      "version": "2.5.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -55,7 +55,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.inputsystem": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -75,7 +75,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.sentis": "1.2.0-exp.2",
+        "com.unity.sentis": "2.0.0",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.physics": "1.0.0"
@@ -126,7 +126,7 @@
         "com.unity.burst": "1.8.14",
         "com.unity.mathematics": "1.3.2",
         "com.unity.ugui": "2.0.0",
-        "com.unity.collections": "2.4.1",
+        "com.unity.collections": "2.4.3",
         "com.unity.modules.physics": "1.0.0",
         "com.unity.modules.terrain": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
@@ -169,12 +169,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.sentis": {
-      "version": "1.2.0-exp.2",
+      "version": "2.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.8.4",
-        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.burst": "1.8.17",
+        "com.unity.collections": "2.4.3",
         "com.unity.modules.imageconversion": "1.0.0"
       },
       "url": "https://packages.unity.com"

--- a/MLAgentsProject/Packages/packages-lock.json
+++ b/MLAgentsProject/Packages/packages-lock.json
@@ -107,7 +107,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.probuilder": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/MLAgentsProject/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/MLAgentsProject/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -24,12 +24,12 @@
             {
                 "type": "UnityEngine.ProBuilder.SemVer, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "key": "about.identifier",
-                "value": "{\"m_Value\":{\"m_Major\":6,\"m_Minor\":0,\"m_Patch\":3,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
+                "value": "{\"m_Value\":{\"m_Major\":6,\"m_Minor\":0,\"m_Patch\":4,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
             },
             {
                 "type": "UnityEngine.ProBuilder.SemVer, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "key": "preferences.version",
-                "value": "{\"m_Value\":{\"m_Major\":6,\"m_Minor\":0,\"m_Patch\":3,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
+                "value": "{\"m_Value\":{\"m_Major\":6,\"m_Minor\":0,\"m_Patch\":4,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
             },
             {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",

--- a/MLAgentsProject/ProjectSettings/ProjectVersion.txt
+++ b/MLAgentsProject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.19f1
-m_EditorVersionWithRevision: 6000.0.19f1 (302b264628f9)
+m_EditorVersion: 6000.0.20f1
+m_EditorVersionWithRevision: 6000.0.20f1 (05208a74e9aa)


### PR DESCRIPTION
### Description

This pull request includes significant updates and improvements to the Tokenizer and related utilities. The main changes are:

- Refactored `DatabaseConstants` to `Constants` for better clarity.
- Enhanced the `Tokenizer` class to handle both full-size (384) and PCA-reduced (3) embeddings.
- Improved exception handling to ensure robustness and data integrity.
- Moved static logic to `TokenizerUtilities` to adhere to DRY principles.
- Updated the `Export` function to generate both `vocab.json` and `tokens.json` files with the correct structure and data.

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### How Has This Been Tested?

The changes have been tested by generating the `tokens.json` file and verifying its structure and data. The following tests were conducted:

- [x] Verified that the `tokens.json` file includes tokens with both full-size and PCA-reduced embeddings.
- [x] Ensured that the `Export` function correctly handles and logs all tokens.
- [x] Confirmed that exception handling works as expected for missing words and incorrect embedding sizes.

**Test Configuration**:
* Firmware version: N/A
* Hardware: NVIDIA 3080 Laptop GPU
* Toolchain: Unity ML-Agents
* SDK: N/A

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Notes

Implementation went smoothly.